### PR TITLE
Try separating integration bucket for different matrix param

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['16.x']
+        node: ['16.x', '18.x']
         os: [ubuntu-latest]
 
     steps:
@@ -30,7 +30,7 @@ jobs:
         env:
           CREDENTIALS_JSON: ${{ secrets.CREDENTIALS_JSON }}
           BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-          PREFIX: github/
+          PREFIX: github/${{ github.run_number }}_${{ github.run_attempt }}/node${{ matrix.node }}_${{ matrix.os }}/
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
[Previously](https://github.com/cofacts/media-manager/commit/bbb3ab33771ab20761753bfa296d7a12d967f07e) we removed testing node v18 because our integration test would clear GCS bucket content under the specified prefix when setting up.

This PR separates the bucket prefix used for each Github workflow run, attempt #, node version and target OS, so that each run will have their own prefix on GCS and thus does not interfere with each other.

## Test result

PR run #69 attempt 1:
https://github.com/cofacts/media-manager/actions/runs/2633901046/attempts/1

Corresponding bucket content:
![image](https://user-images.githubusercontent.com/108608/177917517-c9fae9b4-7311-40ba-8357-3a4c3428087f.png)


PR run #69 rerun (attempt 2):
https://github.com/cofacts/media-manager/actions/runs/2633901046/attempts/2

Corresponding bucket content:
![image](https://user-images.githubusercontent.com/108608/177917789-b647c37d-1d7e-4d83-800d-6bdd4708c2d0.png)

## Others

On the GCS we can setup object lifecycle so that artifacts of old workflow runs are deleted automatically.
<img width="812" alt="image" src="https://user-images.githubusercontent.com/108608/177918354-b0f21421-9137-44fa-8021-79925ee4aef0.png">
