### PR TITLE
Export hashes for easier migration implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import MediaManager from './MediaManager';
 import * as variants from './lib/variants';
-export { MediaManager, variants };
+import * as hashes from './lib/hashes';
+export { MediaManager, variants, hashes };
 export * from './types';


### PR DESCRIPTION
As title.
This PR only exports `hashes` so that user of this library can use `import { hashes } from '@cofacts/media-manager'` to create migration scripts