### PR TITLE
Allow query by ID

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -99,20 +99,20 @@ export type MediaManagerOptions = {
   getVariantSettings?: GetVariantSettingsFn;
 };
 
-export interface QueryOptions {
-  /**
-   * The URL to the file to search for.
-   * It is expected that the URL is:
-   * - accessible
-   * - has correct `Content-Type` header
-   * - has correct `Content-Length` header
-   */
-  url: string;
-}
+/**
+ * Argument for {@link MediaManager.query}. Contains one of:
+ * - `url`: The URL to the file to search for.
+ *   It is expected that the URL is:
+ *   - accessible
+ *   - has correct `Content-Type` header
+ *   - has correct `Content-Length` header
+ * - `id`: The {@link MediaEntry.id} of an media entry, to look for similar media entries.
+ */
+export type QueryOptions = { url: string } | { id: string };
 
 export type InsertOptions = {
   /**
-   * @see {@link QueryOptions.url}
+   * @see {@link QueryOptions}'s url
    */
   url: string;
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -215,5 +215,9 @@ if (process.env.CREDENTIALS_JSON && process.env.BUCKET_NAME) {
         },
       }
     `);
+
+    // Check if can search by ID; should be identical to queryResult
+    const queryResultById = await mediaManager.query({ id: queryResult.queryInfo.id });
+    expect(JSON.stringify(queryResultById)).toEqual(JSON.stringify(queryResult));
   }, 30000);
 }


### PR DESCRIPTION
This PR adds functionality to search similar media entries by media entry ID.

```typescript
mediaManager.query({ id: mediaEntryId });
```

Note that it is prohibited that `id` and `url` are used together. 
