### PR TITLE
fix(MediaManager): use different HTTP streams for each variant

### DIFF
--- a/src/MediaManager.ts
+++ b/src/MediaManager.ts
@@ -1,6 +1,5 @@
 import fetch from 'node-fetch';
 import { Bucket, Storage, File } from '@google-cloud/storage';
-import { pipeline } from 'stream/promises';
 import prepareStream from './lib/prepareStream';
 import { defaultGetVariantSettings, DEFAULT_ORIGINAL_VARIANT_NAME } from './lib/variants';
 import { getFileIDHash, getImageSearchHashes, base64urlHammingDist } from './lib/hashes';
@@ -161,14 +160,17 @@ class MediaManager {
     // Must not await this promise because we still need to pipe body to another writable stream
     // for hash calculation below
     const uploadPromise = Promise.all(
-      variantSettings.map(async ({ transform, contentType }, i) =>
-        pipeline(
-          // Initiate separate HTTP stream here, as each variant may consume the stream differently,
-          // or even ends before reading the whole file.
-          (await fetch(url)).body,
-          transform,
-          tempVariantFiles[i].createWriteStream({ contentType, gzip: 'auto' })
-        )
+      variantSettings.map(
+        async ({ transform, contentType }, i) =>
+          new Promise(async (resolve, reject) => {
+            // Initiate separate HTTP stream here, as each variant may consume the stream differently,
+            // or even ends before reading the whole file.
+            (await fetch(url)).body
+              .pipe(transform)
+              .pipe(tempVariantFiles[i].createWriteStream({ contentType, gzip: 'auto' }))
+              .on('finish', resolve)
+              .on('error', reject);
+          })
       )
     );
 

--- a/src/lib/hashes.ts
+++ b/src/lib/hashes.ts
@@ -73,7 +73,7 @@ export async function getImageSearchHashes(
             sharpProcessors.reduce((sharp, processor) => processor(sharp), sharp())
           );
     const chunks: Buffer[] = [];
-    stream.on('data', chunk => chunks.push(chunk));
+    stream.on('data', (chunk: Buffer) => chunks.push(chunk));
     stream.on('end', () => resolve(Buffer.concat(chunks)));
     stream.on('error', reject);
   });


### PR DESCRIPTION
[use different HTTP streams for each variant](https://github.com/cofacts/media-manager/pull/10/commits/fd66c04c7c45eef8b1b0445e3f6ebf2bd5e5aca2)
- So that the variant's transform stream don't block each other by the stream backpressure mechanism, or does not block others when exits writing before reading the whole file.

[use event handlers on writable instead of pipeline()](https://github.com/cofacts/media-manager/pull/10/commits/bfee77b7d46bc50571a59b29ec2d6ee50bfa9d2b)
- pipeline() does not resolve when input readable is not finished yet
- however, the transform is designed to finish early (such as when only first 5s video is needed), in this case pipeline() would never resolve
- we switch to only look at the last stream (upload to GCS)