### PR TITLE
fix: allow missing content-length from media URLs

### DIFF
--- a/src/lib/__tests__/hashes.test.ts
+++ b/src/lib/__tests__/hashes.test.ts
@@ -44,6 +44,19 @@ describe('getImageSearchHashes', () => {
           `);
   });
 
+  it('generates same hashes for small files when size=0 (unknown content-length)', async () => {
+    const smallImage = path.resolve(__dirname, '../../../test/fixtures/small.jpg');
+    const infileStream = fs.createReadStream(smallImage);
+
+    await expect(getImageSearchHashes(infileStream, 0, 'image/jpeg')).resolves
+      .toMatchInlineSnapshot(`
+            Array [
+              "vDph4g",
+              "__-AD6SDgAebG8cbwifBB-Dj0yPjo8ETgAOAA4P_8_8",
+            ]
+          `);
+  });
+
   it('generates hashes for large files', async () => {
     const bigImage = path.resolve(__dirname, '../../../test/fixtures/big.jpg');
     const infileStream = fs.createReadStream(bigImage);

--- a/src/lib/prepareStream.ts
+++ b/src/lib/prepareStream.ts
@@ -33,8 +33,8 @@ async function prepareStream({ url }: PrepareStreamOptions): Promise<PrepareStre
 
   if (!contentTypeBeforeSlash) throw new Error(`No content type header provided by ${url}`);
 
+  // size = 0 when content-length header is absent; callers treat it as unknown and skip size-based optimizations.
   const size = +(resp.headers.get('content-length') ?? 0);
-  if (size === 0) throw new Error(`No content-length provided by ${url}, or content-length is 0`);
 
   let type: MediaType;
   switch (contentTypeBeforeSlash) {


### PR DESCRIPTION
## Summary

- LINE's content API sometimes omits `Content-Length` (e.g. chunked transfer encoding), causing `prepareStream` to throw `"No content-length provided"` on every such image — breaking image search in the LINE bot
- `size` is only used to decide whether to pre-resize before hashing (`> 1MB` threshold); when `size = 0` (unknown), the condition is `false` and we skip resize, which is the safe behaviour for typically small LINE images
- Removes the throw; adds a unit test confirming `size=0` produces the same hash as the known-size path for a small image

## Test plan

- [ ] Unit tests pass (`npm test -- --testPathPattern=hashes`)
- [ ] CI green
- [ ] Deploy new version to rumors-api and verify LINE bot image messages no longer log "No content-length provided"

🤖 Generated with [Claude Code](https://claude.com/claude-code)